### PR TITLE
Modify the supernova notebook to be compatible with DP02

### DIFF
--- a/dia_exploration/dia_supernova.ipynb
+++ b/dia_exploration/dia_supernova.ipynb
@@ -231,19 +231,11 @@
    "source": [
     "## 1. Get a Supernova from the truth table\n",
     "\n",
-    "Query the truth match catalog with the TAP service. Use central coordinates of DC2. Use a 5 degree radius. Use is_variable = 1 (true) to only return variables. Use truth_type = 3 to only return Type Ia supernovae. Use is_unique_truth_entry = 'true' to ensure good truth-table matches only. Use redshift < 0.3 to be more likely to get a full light curve with lots of data points.\n",
+    "Query the truth match catalog with the TAP service. Use coordinates near the center of DC2. Use a 0.5 degree radius. Use is_variable = 1 (true) to only return variables. Use is_variable = 1 (true) to only return variables. Use truth_type = 3 to only return Type Ia supernovae. Use is_unique_truth_entry = 'true' to ensure good truth-table matches only. Use redshift < 0.3 to be more likely to get a full light curve with lots of data points.\n",
     "\n",
     "Get the coordinates and all the useful information through the query. \n",
     "\n",
     "The schema browser for each table is here: https://dm.lsst.org/sdm_schemas/browser/dp02.html"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "33fae00d-bf8f-4c19-a1b2-1e7dbc5b7531",
-   "metadata": {},
-   "source": [
-    "**N.B.** New truth tables are projected to be released in the next two weeks, and it will no longer be necessary to use the DP0.1 truth_match table. Stay tooned for updates!"
    ]
   },
   {
@@ -253,11 +245,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = service.search(\"SELECT ra, dec, id, host_galaxy, match_sep, match_objectId, redshift, tract, patch \"\\\n",
-    "                         \"FROM dp01_dc2_catalogs.truth_match \"\\\n",
-    "                         \"WHERE CONTAINS(POINT('ICRS', ra, dec), \"\\\n",
-    "                         \"CIRCLE('ICRS', 62.0, -37.0, 5.0)) = 1 \"\\\n",
-    "                         \"AND is_variable = 1 AND truth_type = 3 AND is_unique_truth_entry = 'true' AND redshift < 0.3 \",\\\n",
+    "%%time\n",
+    "results = service.search(\"SELECT ts.ra, ts.dec, ts.id, ts.host_galaxy, ts.redshift \"\\\n",
+    "                         \"FROM dp02_dc2_catalogs.TruthSummary AS ts \"\n",
+    "                         \"WHERE CONTAINS(POINT('ICRS', ts.ra, ts.dec), \"\\\n",
+    "                         \"CIRCLE('ICRS', 64.0, -35.5, 0.5)) = 1 \"\\\n",
+    "                         \"AND ts.is_variable = 1 AND ts.truth_type = 3 AND ts.redshift < 0.3 \",\\\n",
     "                         maxrec=10000)"
    ]
   },
@@ -286,7 +279,7 @@
    "metadata": {},
    "source": [
     "### 1.1 Select a Supernova\n",
-    "Un-comment the line of the SN you want to analyze"
+    "SN we want to analyze"
    ]
   },
   {
@@ -296,13 +289,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#SN = data.loc[data['id'] == 'MS_9684_2'] # Object with a big offset in all the bands\n",
-    "\n",
-    "SN = data.loc[data['id'] == 'MS_9686_140'] # Very good object!\n",
-    "\n",
-    "#SN = data.loc[data['id'] == 'MS_9813_197'] # Offset in the i-band\n",
-    "\n",
-    "#SN = data.loc[data['id'] == 'MS_9686_9'] # Offset in the r-band"
+    "SN = data.loc[data['id'] == 'MS_9686_140'] # Very good object!\n"
    ]
   },
   {
@@ -323,41 +310,6 @@
     "# Get the coordinates\n",
     "SN_ra, SN_dec = SN['ra'].values[0]*u.deg, SN['dec'].values[0]*u.deg\n",
     "targ_coord = SkyCoord(ra=SN_ra,dec=SN_dec)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2e451549-ece2-4539-8187-3e3e5e08f56d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get tract and pacth (to retrieve the image later)\n",
-    "tract = SN['tract'].values[0]\n",
-    "patch = SN['patch'].values[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a6caff1a-dab9-4aaa-9728-a206b010e362",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Convert patch from the \"Gen2\" Butler tuple format to the \"Gen3\" single integer\n",
-    "patch = patch.split(',')\n",
-    "patch = (7*int(patch[1]))+int(patch[0])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "50aa211d-df85-472b-bdd0-22dff6f88b00",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get the true host_galaxy ID\n",
-    "gal_true = SN['match_objectId'].values[0]"
    ]
   },
   {
@@ -813,6 +765,23 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cd868925-b096-43b7-82aa-8e92693020f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get tract and pacth (to retrieve the image)\n",
+    "results = service.search(\"SELECT patch, tract \"\n",
+    "                         \"FROM dp02_dc2_catalogs.ForcedSourceOnDiaObject \"\n",
+    "                         \"WHERE diaObjectId = \"+str(sel_objid))\n",
+    "\n",
+    "patch, tract = results.to_table()[0]\n",
+    "del results\n",
+    "print(patch, tract)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a426ba8",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
dp01_dc2_catalogs.truth_match is not used any more - replaced with dp02_dc2_catalogs.TruthSummary. Patch, tract info is not taken from dp02_dc2_catalogs.ForcedSourceOnDiaObject.Search radius at the start set to 0.5 degrees, to speed up the execution.